### PR TITLE
feat: 增加页面模型关联跳转逻辑

### DIFF
--- a/webui/src/routes/models.tsx
+++ b/webui/src/routes/models.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -58,6 +59,7 @@ const formSchema = z.object({
 });
 
 export default function ModelsPage() {
+  const navigate = useNavigate();
   const [models, setModels] = useState<Model[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -185,6 +187,14 @@ export default function ModelsPage() {
                 <TableCell>{model.MaxRetry}</TableCell>
                 <TableCell>{model.TimeOut}</TableCell>
                 <TableCell className="space-x-2">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    className="bg-blue-600 hover:bg-blue-500 text-white dark:bg-blue-500 dark:hover:bg-blue-400"
+                    onClick={() => navigate(`/model-providers?modelId=${model.ID}`)}
+                  >
+                    关联
+                  </Button>
                   <Button 
                     variant="outline" 
                     size="sm" 
@@ -232,6 +242,14 @@ export default function ModelsPage() {
                 <p className="text-sm text-gray-500">ID: {model.ID}</p>
               </div>
               <div className="flex space-x-2">
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="bg-blue-600 hover:bg-blue-500 text-white dark:bg-blue-500 dark:hover:bg-blue-400"
+                  onClick={() => navigate(`/model-providers?modelId=${model.ID}`)}
+                >
+                  关联
+                </Button>
                 <Button 
                   variant="outline" 
                   size="sm" 


### PR DESCRIPTION

<img width="1266" height="460" alt="image" src="https://github.com/user-attachments/assets/9c6d0a1a-ae45-44ed-a20b-e644a611b1b6" />


点击关联，直接跳转到对应模型的映射页面