### PR TITLE
feat: add per-provider HTTP proxy support

### DIFF
--- a/handler/api.go
+++ b/handler/api.go
@@ -23,6 +23,7 @@ type ProviderRequest struct {
 	Type    string `json:"type"`
 	Config  string `json:"config"`
 	Console string `json:"console"`
+	Proxy   string `json:"proxy"`
 }
 
 // ModelRequest represents the request body for creating/updating a model
@@ -101,7 +102,7 @@ func GetProviderModels(c *gin.Context) {
 		common.InternalServerError(c, err.Error())
 		return
 	}
-	chatModel, err := providers.New(provider.Type, provider.Config)
+	chatModel, err := providers.New(provider.Type, provider.Config, provider.Proxy)
 	if err != nil {
 		common.InternalServerError(c, "Failed to get models: "+err.Error())
 		return
@@ -139,6 +140,7 @@ func CreateProvider(c *gin.Context) {
 		Type:    req.Type,
 		Config:  req.Config,
 		Console: req.Console,
+		Proxy:   req.Proxy,
 	}
 
 	if err := gorm.G[models.Provider](models.DB).Create(c.Request.Context(), &provider); err != nil {
@@ -180,6 +182,7 @@ func UpdateProvider(c *gin.Context) {
 		Type:    req.Type,
 		Config:  req.Config,
 		Console: req.Console,
+		Proxy:   req.Proxy,
 	}
 
 	if _, err := gorm.G[models.Provider](models.DB).Where("id = ?", id).Updates(c.Request.Context(), updates); err != nil {

--- a/handler/test.go
+++ b/handler/test.go
@@ -98,14 +98,14 @@ func ProviderTestHandler(c *gin.Context) {
 	}
 
 	// Create the provider instance
-	providerInstance, err := providers.New(chatModel.Type, chatModel.Config)
+	providerInstance, err := providers.New(chatModel.Type, chatModel.Config, chatModel.Proxy)
 	if err != nil {
 		common.BadRequest(c, "Failed to create provider: "+err.Error())
 		return
 	}
 
 	// Test connectivity by fetching models
-	client := providers.GetClient(time.Second * time.Duration(30))
+	client := providers.GetClient(time.Second*time.Duration(30), chatModel.Proxy)
 	var testBody []byte
 	switch chatModel.Type {
 	case consts.StyleOpenAI:
@@ -297,6 +297,7 @@ type ChatModel struct {
 	Type            string            `json:"type"`
 	Model           string            `json:"model"`
 	Config          string            `json:"config"`
+	Proxy           string            `json:"proxy,omitempty"`
 	WithHeader      *bool             `json:"with_header,omitempty"`
 	CustomerHeaders map[string]string `json:"customer_headers,omitempty"`
 }
@@ -319,6 +320,7 @@ func FindChatModel(ctx context.Context, id string) (*ChatModel, error) {
 		Type:            provider.Type,
 		Model:           modelWithProvider.ProviderModel,
 		Config:          provider.Config,
+		Proxy:           provider.Proxy,
 		WithHeader:      modelWithProvider.WithHeader,
 		CustomerHeaders: modelWithProvider.CustomerHeaders,
 	}, nil

--- a/models/model.go
+++ b/models/model.go
@@ -13,6 +13,7 @@ type Provider struct {
 	Type    string
 	Config  string
 	Console string // 控制台地址
+	Proxy   string // HTTP 代理地址
 }
 
 type AnthropicConfig struct {

--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -16,6 +16,7 @@ type Anthropic struct {
 	BaseURL string `json:"base_url"`
 	APIKey  string `json:"api_key"`
 	Version string `json:"version"`
+	Proxy   string `json:"-"`
 }
 
 func (a *Anthropic) BuildReq(ctx context.Context, header http.Header, model string, rawBody []byte) (*http.Request, error) {
@@ -58,7 +59,7 @@ func (a *Anthropic) Models(ctx context.Context) ([]Model, error) {
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("x-api-key", a.APIKey)
 	req.Header.Set("anthropic-version", a.Version)
-	res, err := http.DefaultClient.Do(req)
+	res, err := GetClient(30*time.Second, a.Proxy).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/cache.go
+++ b/providers/cache.go
@@ -3,17 +3,23 @@ package providers
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 )
 
+type clientKey struct {
+	timeout time.Duration
+	proxy   string
+}
+
 type clientCache struct {
 	mu      sync.RWMutex
-	clients map[time.Duration]*http.Client
+	clients map[clientKey]*http.Client
 }
 
 var cache = &clientCache{
-	clients: make(map[time.Duration]*http.Client),
+	clients: make(map[clientKey]*http.Client),
 }
 
 var dialer = &net.Dialer{
@@ -21,12 +27,14 @@ var dialer = &net.Dialer{
 	KeepAlive: 30 * time.Second,
 }
 
-// GetClient returns an http.Client with the specified responseHeaderTimeout.
-// If a client with the same timeout already exists, it returns the cached one.
+// GetClient returns an http.Client with the specified responseHeaderTimeout and proxy.
+// If a client with the same timeout and proxy already exists, it returns the cached one.
 // Otherwise, it creates a new client and caches it.
-func GetClient(responseHeaderTimeout time.Duration) *http.Client {
+func GetClient(responseHeaderTimeout time.Duration, proxyURL string) *http.Client {
+	key := clientKey{timeout: responseHeaderTimeout, proxy: proxyURL}
+
 	cache.mu.RLock()
-	if client, exists := cache.clients[responseHeaderTimeout]; exists {
+	if client, exists := cache.clients[key]; exists {
 		cache.mu.RUnlock()
 		return client
 	}
@@ -36,12 +44,19 @@ func GetClient(responseHeaderTimeout time.Duration) *http.Client {
 	defer cache.mu.Unlock()
 
 	// Double-check after acquiring write lock
-	if client, exists := cache.clients[responseHeaderTimeout]; exists {
+	if client, exists := cache.clients[key]; exists {
 		return client
 	}
 
+	proxyFunc := http.ProxyFromEnvironment
+	if proxyURL != "" {
+		if u, err := url.Parse(proxyURL); err == nil {
+			proxyFunc = http.ProxyURL(u)
+		}
+	}
+
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
+		Proxy:                 proxyFunc,
 		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
@@ -56,6 +71,6 @@ func GetClient(responseHeaderTimeout time.Duration) *http.Client {
 		Timeout:   0, // No overall timeout, let ResponseHeaderTimeout control header timing
 	}
 
-	cache.clients[responseHeaderTimeout] = client
+	cache.clients[key] = client
 	return client
 }

--- a/providers/gemini.go
+++ b/providers/gemini.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/atopos31/llmio/consts"
 )
@@ -17,6 +18,7 @@ import (
 type Gemini struct {
 	BaseURL string `json:"base_url"`
 	APIKey  string `json:"api_key"`
+	Proxy   string `json:"-"`
 }
 
 func (g *Gemini) BuildReq(ctx context.Context, header http.Header, model string, rawBody []byte) (*http.Request, error) {
@@ -67,7 +69,7 @@ func (g *Gemini) Models(ctx context.Context) ([]Model, error) {
 	req.Header.Set("x-goog-api-key", g.APIKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := GetClient(30*time.Second, g.Proxy).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/openai.go
+++ b/providers/openai.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/tidwall/sjson"
 )
@@ -13,6 +14,7 @@ import (
 type OpenAI struct {
 	BaseURL string `json:"base_url"`
 	APIKey  string `json:"api_key"`
+	Proxy   string `json:"-"`
 }
 
 func (o *OpenAI) BuildReq(ctx context.Context, header http.Header, model string, rawBody []byte) (*http.Request, error) {
@@ -39,7 +41,7 @@ func (o *OpenAI) Models(ctx context.Context) ([]Model, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.APIKey))
-	res, err := http.DefaultClient.Do(req)
+	res, err := GetClient(30*time.Second, o.Proxy).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/openai_res.go
+++ b/providers/openai_res.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/tidwall/sjson"
 )
@@ -14,6 +15,7 @@ import (
 type OpenAIRes struct {
 	BaseURL string `json:"base_url"`
 	APIKey  string `json:"api_key"`
+	Proxy   string `json:"-"`
 }
 
 func (o *OpenAIRes) BuildReq(ctx context.Context, header http.Header, model string, rawBody []byte) (*http.Request, error) {
@@ -40,7 +42,7 @@ func (o *OpenAIRes) Models(ctx context.Context) ([]Model, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.APIKey))
-	res, err := http.DefaultClient.Do(req)
+	res, err := GetClient(30*time.Second, o.Proxy).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -26,33 +26,35 @@ type Provider interface {
 	Models(ctx context.Context) ([]Model, error)
 }
 
-func New(Type, providerConfig string) (Provider, error) {
+func New(Type, providerConfig, proxy string) (Provider, error) {
 	switch Type {
 	case consts.StyleOpenAI:
 		var openai OpenAI
 		if err := json.Unmarshal([]byte(providerConfig), &openai); err != nil {
 			return nil, errors.New("invalid openai config")
 		}
-
+		openai.Proxy = proxy
 		return &openai, nil
 	case consts.StyleOpenAIRes:
 		var openaiRes OpenAIRes
 		if err := json.Unmarshal([]byte(providerConfig), &openaiRes); err != nil {
 			return nil, errors.New("invalid openai-res config")
 		}
-
+		openaiRes.Proxy = proxy
 		return &openaiRes, nil
 	case consts.StyleAnthropic:
 		var anthropic Anthropic
 		if err := json.Unmarshal([]byte(providerConfig), &anthropic); err != nil {
 			return nil, errors.New("invalid anthropic config")
 		}
+		anthropic.Proxy = proxy
 		return &anthropic, nil
 	case consts.StyleGemini:
 		var gemini Gemini
 		if err := json.Unmarshal([]byte(providerConfig), &gemini); err != nil {
 			return nil, errors.New("invalid gemini config")
 		}
+		gemini.Proxy = proxy
 		return &gemini, nil
 	default:
 		return nil, errors.New("unknown provider")

--- a/service/chat.go
+++ b/service/chat.go
@@ -50,7 +50,6 @@ func BalanceChat(ctx context.Context, start time.Time, style string, before Befo
 	if before.Stream {
 		responseHeaderTimeout = responseHeaderTimeout / 3
 	}
-	client := providers.GetClient(responseHeaderTimeout)
 
 	authKeyID, _ := ctx.Value(consts.ContextKeyAuthKeyID).(uint)
 
@@ -78,10 +77,12 @@ func BalanceChat(ctx context.Context, start time.Time, style string, before Befo
 
 			provider := providerMap[modelWithProvider.ProviderID]
 
-			chatModel, err := providers.New(provider.Type, provider.Config)
+			chatModel, err := providers.New(provider.Type, provider.Config, provider.Proxy)
 			if err != nil {
 				return nil, nil, err
 			}
+
+			client := providers.GetClient(responseHeaderTimeout, provider.Proxy)
 
 			slog.Info("using provider", "provider", provider.Name, "model", modelWithProvider.ProviderModel)
 

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -8,6 +8,7 @@ export interface Provider {
   Type: string;
   Config: string;
   Console: string;
+  Proxy: string;
 }
 
 export interface Model {
@@ -143,6 +144,7 @@ export async function createProvider(provider: {
   type: string;
   config: string;
   console: string;
+  proxy: string;
 }): Promise<Provider> {
   return apiRequest<Provider>('/providers', {
     method: 'POST',
@@ -155,6 +157,7 @@ export async function updateProvider(id: number, provider: {
   type?: string;
   config?: string;
   console?: string;
+  proxy?: string;
 }): Promise<Provider> {
   return apiRequest<Provider>(`/providers/${id}`, {
     method: 'PUT',

--- a/webui/src/routes/providers.tsx
+++ b/webui/src/routes/providers.tsx
@@ -121,6 +121,7 @@ const formSchema = z.object({
   type: z.string().min(1, { message: "提供商类型不能为空" }),
   config: z.string().min(1, { message: "配置不能为空" }),
   console: z.string().optional(),
+  proxy: z.string().optional(),
 });
 
 export default function ProvidersPage() {
@@ -147,7 +148,7 @@ export default function ProvidersPage() {
   // 初始化表单
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: { name: "", type: "", config: "", console: "" },
+    defaultValues: { name: "", type: "", config: "", console: "", proxy: "" },
   });
   const selectedProviderType = form.watch("type");
 
@@ -306,11 +307,12 @@ export default function ProvidersPage() {
         name: values.name,
         type: values.type,
         config: values.config,
-        console: values.console || ""
+        console: values.console || "",
+        proxy: values.proxy || "",
       });
       setOpen(false);
       toast.success(`提供商 ${values.name} 创建成功`);
-      form.reset({ name: "", type: "", config: "", console: "" });
+      form.reset({ name: "", type: "", config: "", console: "", proxy: "" });
       fetchProviders();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -326,12 +328,13 @@ export default function ProvidersPage() {
         name: values.name,
         type: values.type,
         config: values.config,
-        console: values.console || ""
+        console: values.console || "",
+        proxy: values.proxy || "",
       });
       setOpen(false);
       toast.success(`提供商 ${values.name} 更新成功`);
       setEditingProvider(null);
-      form.reset({ name: "", type: "", config: "", console: "" });
+      form.reset({ name: "", type: "", config: "", console: "", proxy: "" });
       fetchProviders();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -363,6 +366,7 @@ export default function ProvidersPage() {
       type: provider.Type,
       config: provider.Config,
       console: provider.Console || "",
+      proxy: provider.Proxy || "",
     });
     setOpen(true);
   };
@@ -387,6 +391,7 @@ export default function ProvidersPage() {
       type: defaultType,
       config: defaultConfig,
       console: "",
+      proxy: "",
     });
     setOpen(true);
   };
@@ -734,6 +739,20 @@ export default function ProvidersPage() {
                         />
                       </FormControl>
                     )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="proxy"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>HTTP 代理</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="http://192.168.1.2:1234" />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION
Allow each provider to configure an individual HTTP proxy address. The proxy setting is stored in the Provider model, passed through to all provider implementations, and used when building HTTP clients. The client cache is keyed by both timeout and proxy URL. The frontend exposes a proxy field in the provider configuration form.
<img width="419" height="502" alt="屏幕截图 2026-02-07 104317" src="https://github.com/user-attachments/assets/58517911-0dc2-4dfb-8513-44505250ffb0" />
<img width="810" height="973" alt="屏幕截图 2026-02-07 104402" src="https://github.com/user-attachments/assets/968a5f1f-771c-4235-a6e7-02083a30a0e7" />
