### PR TITLE
feat(provider): support body error matcher for 200 responses

### DIFF
--- a/handler/api.go
+++ b/handler/api.go
@@ -19,11 +19,12 @@ import (
 
 // ProviderRequest represents the request body for creating/updating a provider
 type ProviderRequest struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Config  string `json:"config"`
-	Console string `json:"console"`
-	Proxy   string `json:"proxy"`
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	Config       string `json:"config"`
+	Console      string `json:"console"`
+	Proxy        string `json:"proxy"`
+	ErrorMatcher string `json:"error_matcher"`
 }
 
 // ModelRequest represents the request body for creating/updating a model
@@ -136,11 +137,12 @@ func CreateProvider(c *gin.Context) {
 	}
 
 	provider := models.Provider{
-		Name:    req.Name,
-		Type:    req.Type,
-		Config:  req.Config,
-		Console: req.Console,
-		Proxy:   req.Proxy,
+		Name:         req.Name,
+		Type:         req.Type,
+		Config:       req.Config,
+		Console:      req.Console,
+		Proxy:        req.Proxy,
+		ErrorMatcher: req.ErrorMatcher,
 	}
 
 	if err := gorm.G[models.Provider](models.DB).Create(c.Request.Context(), &provider); err != nil {
@@ -178,11 +180,12 @@ func UpdateProvider(c *gin.Context) {
 
 	// Update fields
 	updates := models.Provider{
-		Name:    req.Name,
-		Type:    req.Type,
-		Config:  req.Config,
-		Console: req.Console,
-		Proxy:   req.Proxy,
+		Name:         req.Name,
+		Type:         req.Type,
+		Config:       req.Config,
+		Console:      req.Console,
+		Proxy:        req.Proxy,
+		ErrorMatcher: req.ErrorMatcher,
 	}
 
 	if _, err := gorm.G[models.Provider](models.DB).Where("id = ?", id).Updates(c.Request.Context(), updates); err != nil {

--- a/models/model.go
+++ b/models/model.go
@@ -10,11 +10,12 @@ import (
 
 type Provider struct {
 	gorm.Model
-	Name    string
-	Type    string
-	Config  string
-	Console string // 控制台地址
-	Proxy   string // HTTP 代理地址
+	Name         string
+	Type         string
+	Config       string
+	Console      string // 控制台地址
+	Proxy        string // HTTP 代理地址
+	ErrorMatcher string // 响应体错误识别规则，多行或分号分隔 sample
 }
 
 type AnthropicConfig struct {

--- a/service/provider_error_matcher.go
+++ b/service/provider_error_matcher.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"strings"
+	"unicode"
+)
+
+func splitProviderErrorMatchers(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ';' || r == '；'
+	})
+
+	matchers := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		matchers = append(matchers, part)
+	}
+	return matchers
+}
+
+func compactLower(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func matchProviderBodyError(body string, rawMatchers string) (bool, string) {
+	matchers := splitProviderErrorMatchers(rawMatchers)
+	if len(matchers) == 0 {
+		return false, ""
+	}
+
+	bodyLower := strings.ToLower(body)
+	bodyCompact := compactLower(body)
+	for _, matcher := range matchers {
+		matcherLower := strings.ToLower(matcher)
+		if strings.Contains(bodyLower, matcherLower) {
+			return true, matcher
+		}
+
+		matcherCompact := compactLower(matcherLower)
+		if matcherCompact != "" && strings.Contains(bodyCompact, matcherCompact) {
+			return true, matcher
+		}
+	}
+
+	return false, ""
+}

--- a/service/provider_error_matcher_test.go
+++ b/service/provider_error_matcher_test.go
@@ -1,0 +1,61 @@
+package service
+
+import "testing"
+
+func TestSplitProviderErrorMatchers(t *testing.T) {
+	got := splitProviderErrorMatchers("\"status\":\"439\";\n\"status\": \"500\"；API Token has expired")
+	want := []string{`"status":"439"`, `"status": "500"`, "API Token has expired"}
+
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d, want %d, got=%v", len(got), len(want), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d]=%q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMatchProviderBodyError(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		matchers    string
+		wantMatched bool
+	}{
+		{
+			name:        "json matcher with different spaces",
+			body:        `{"status":"439","msg":"token expired"}`,
+			matchers:    `"status": "439";"status": "500"`,
+			wantMatched: true,
+		},
+		{
+			name:        "plain text matcher",
+			body:        `{"msg":"Your API Token has expired."}`,
+			matchers:    `API Token has expired`,
+			wantMatched: true,
+		},
+		{
+			name:        "no matcher config",
+			body:        `{"status":"439"}`,
+			matchers:    ``,
+			wantMatched: false,
+		},
+		{
+			name:        "not matched",
+			body:        `{"status":"200","msg":"ok"}`,
+			matchers:    `"status":"439";token expired`,
+			wantMatched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, _ := matchProviderBodyError(tt.body, tt.matchers)
+			if matched != tt.wantMatched {
+				t.Fatalf("matched=%v, want %v", matched, tt.wantMatched)
+			}
+		})
+	}
+}

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -9,6 +9,7 @@ export interface Provider {
   Config: string;
   Console: string;
   Proxy: string;
+  ErrorMatcher: string;
 }
 
 export interface Model {
@@ -145,6 +146,7 @@ export async function createProvider(provider: {
   config: string;
   console: string;
   proxy: string;
+  error_matcher: string;
 }): Promise<Provider> {
   return apiRequest<Provider>('/providers', {
     method: 'POST',
@@ -158,6 +160,7 @@ export async function updateProvider(id: number, provider: {
   config?: string;
   console?: string;
   proxy?: string;
+  error_matcher?: string;
 }): Promise<Provider> {
   return apiRequest<Provider>(`/providers/${id}`, {
     method: 'PUT',

--- a/webui/src/routes/providers/provider-form-dialog.tsx
+++ b/webui/src/routes/providers/provider-form-dialog.tsx
@@ -212,6 +212,30 @@ export function ProviderFormDialog({
 
             <FormField
               control={form.control}
+              name="error_matcher"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>响应体错误识别</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder={`示例（每行或分号分隔）:
+"status":"439"
+"status":"500"
+API Token has expired`}
+                      className="resize-y min-h-[88px]"
+                    />
+                  </FormControl>
+                  <p className="text-xs text-muted-foreground">
+                    命中任意 sample 即视为错误，用于 200 但 body 返回错误的渠道。
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
               name="console"
               render={({ field }) => (
                 <FormItem>

--- a/webui/src/routes/providers/use-provider-form.ts
+++ b/webui/src/routes/providers/use-provider-form.ts
@@ -19,6 +19,7 @@ export const providerFormSchema = z.object({
   config: z.string().min(1, { message: "配置不能为空" }),
   console: z.string().optional(),
   proxy: z.string().optional(),
+  error_matcher: z.string().optional(),
 });
 
 export type ProviderFormValues = z.infer<typeof providerFormSchema>;
@@ -29,6 +30,7 @@ const defaultFormValues: ProviderFormValues = {
   config: "",
   console: "",
   proxy: "",
+  error_matcher: "",
 };
 
 type UseProviderFormParams = {
@@ -126,6 +128,7 @@ export const useProviderForm = ({
       config: provider.Config,
       console: provider.Console || "",
       proxy: provider.Proxy || "",
+      error_matcher: provider.ErrorMatcher || "",
     });
     setOpen(true);
   };
@@ -146,6 +149,7 @@ export const useProviderForm = ({
       config: getTemplateInitialConfig(firstTemplate),
       console: "",
       proxy: "",
+      error_matcher: "",
     });
     setOpen(true);
   };
@@ -159,6 +163,7 @@ export const useProviderForm = ({
           config: values.config,
           console: values.console || "",
           proxy: values.proxy || "",
+          error_matcher: values.error_matcher || "",
         });
         toast.success(`提供商 ${values.name} 更新成功`);
         setEditingProvider(null);
@@ -169,6 +174,7 @@ export const useProviderForm = ({
           config: values.config,
           console: values.console || "",
           proxy: values.proxy || "",
+          error_matcher: values.error_matcher || "",
         });
         toast.success(`提供商 ${values.name} 创建成功`);
       }


### PR DESCRIPTION
渠道设置添加一个判断选项

<img width="482" height="150" alt="图片" src="https://github.com/user-attachments/assets/9231d2a3-6cf7-4444-9f58-6e4951546ed2" />

对于返回状态 200 但是带有报错信息的渠道，原先被视为成功，返回信息如下

<img width="928" height="1004" alt="iShot_2026-02-24_16 58 15" src="https://github.com/user-attachments/assets/0611fe58-9aa9-4fa1-80f8-c906d9bde58c" />

修改后可以添加判断选项

<img width="558" height="862" alt="iShot_2026-02-24_16 59 05" src="https://github.com/user-attachments/assets/31b7d599-392e-43af-a52b-0546b542af01" />

添加后被识别为错误

<img width="719" height="737" alt="iShot_2026-02-24_17 00 07" src="https://github.com/user-attachments/assets/a8b7e652-24e9-4e99-bd80-9290570b979b" />

并且可以正常触发 `balancers/` 的重试机制

<img width="2018" height="257" alt="iShot_2026-02-24_17 00 17" src="https://github.com/user-attachments/assets/e20e236a-f7c8-456f-9e42-689429e0ef24" />
