### PR TITLE
修复关联管理状态条误判 running 请求为失败的问题

### DIFF
--- a/handler/api.go
+++ b/handler/api.go
@@ -503,6 +503,7 @@ func GetModelProviderStatus(c *gin.Context) {
 		Where("provider_name = ?", provider.Name).
 		Where("provider_model = ?", providerModel).
 		Where("name = ?", modelName).
+		Where("status != ?", consts.StatusRunning).
 		Limit(10).
 		Order("created_at DESC").
 		Find(c.Request.Context())


### PR DESCRIPTION
## 问题描述

当请求日志中存在 `running` 状态的记录时，关联管理页面（Model Providers）的状态条会错误地将其显示为红色（失败），导致提供商状态被误判为不可靠。

**复现场景**：
1. 发起一个模型请求，日志中记录为 `status: running`
2. 在关联管理页面查看该模型-提供商组合的状态条
3. 状态条中出现红色条，但实际上该请求仍在进行中，并未失败

## 根本原因

`GetModelProviderStatus` API 在查询提供商状态时，**未排除 `running` 状态的记录**，将所有非 `success` 的状态（包括 `running` 和 `error`）都视为失败。

**相关代码**：
```go
// handler/api.go:GetModelProviderStatus
logs, err := gorm.G[models.ChatLog](models.DB).
    Where("provider_name = ?", provider.Name).
    Where("provider_model = ?", providerModel).
    Where("name = ?", modelName).
    // ❌ 缺少对 status=running 的过滤
    Limit(10).
    Order("created_at DESC").
    Find(c.Request.Context())

for _, log := range logs {
    status = append(status, log.Status == consts.StatusSuccess)  // running → false
}
```

## 解决方案

在查询条件中**排除 `running` 状态**，只统计已完成的请求（success/error）来计算状态条。

**改动位置**：`handler/api.go:506`

```go
logs, err := gorm.G[models.ChatLog](models.DB).
    Where("provider_name = ?", provider.Name).
    Where("provider_model = ?", providerModel).
    Where("name = ?", modelName).
    Where("status != ?", consts.StatusRunning).  // ← 新增：过滤进行中的请求
    Limit(10).
    Order("created_at DESC").
    Find(c.Request.Context())
```

## 修复效果对比

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 最近10次：9成功 + 1次 running | 9绿1红 ❌（误判） | 9绿 ✅（正确） |
| 最近10次：全部 running | 10红 ❌（全部误判） | 无数据 ✅（合理） |
| 最近10次：5成功 + 5失败 | 5绿5红 ✅（正确） | 5绿5红 ✅（不变）