### PR TITLE
fix(stream): 避免 IO 日志前置写入阻塞流式首包

### DIFF
--- a/service/chat.go
+++ b/service/chat.go
@@ -182,14 +182,6 @@ func RecordRetryLog(ctx context.Context, retryLog chan models.ChatLog) {
 func RecordLog(ctx context.Context, reqStart time.Time, reader io.ReadCloser, processer Processer, logId uint, before Before, ioLog bool) {
 	recordFunc := func() error {
 		defer reader.Close()
-		if ioLog {
-			if err := gorm.G[models.ChatIO](models.DB).Create(ctx, &models.ChatIO{
-				Input: string(before.raw),
-				LogId: logId,
-			}); err != nil {
-				return err
-			}
-		}
 		log, output, err := processer(ctx, reader, before.Stream, reqStart)
 		if err != nil {
 			return err
@@ -199,7 +191,11 @@ func RecordLog(ctx context.Context, reqStart time.Time, reader io.ReadCloser, pr
 			return err
 		}
 		if ioLog {
-			if _, err := gorm.G[models.ChatIO](models.DB).Where("log_id = ?", logId).Updates(ctx, models.ChatIO{OutputUnion: *output}); err != nil {
+			if err := gorm.G[models.ChatIO](models.DB).Create(ctx, &models.ChatIO{
+				LogId:       logId,
+				Input:       string(before.raw),
+				OutputUnion: *output,
+			}); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## 背景
在流式请求场景下，IO 日志会先写入一条仅包含 Input 的 `chat_io` 记录，再在响应处理完成后补写 Output。  
这会把一次数据库写操作放在流式处理前，可能影响首包返回时延（TTFB）。

## 主要变更
- 调整 `RecordLog` 的 IO 日志落库时机：移除“前置 Create”。
- 将原本“Create(Input) + Updates(Output)”改为“处理完成后一次性 Create(Input + OutputUnion)”。
- 保持原有 `ChatLog` 成功/失败状态更新逻辑不变。

## 变更文件
- `service/chat.go`（1 个文件，`+5/-9`）

## 预期收益
- 避免 IO 日志前置写入阻塞流式首包。
- 减少一次数据库写操作（2 次降为 1 次），简化日志写入路径。
- 降低 `chat_io` 中间态数据（仅 Input 无 Output）的出现概率。

## 风险与兼容性
- 当 `processer` 返回错误时，不会再创建仅包含 Input 的 `chat_io` 记录（与旧行为相比有变化）。
- 不涉及接口协议变更，对调用方兼容。

## 验证
- 已执行：`go test ./...`
- 结果：通过  
  - `ok github.com/atopos31/llmio/balancers`
  - `ok github.com/atopos31/llmio/middleware`
  - `ok github.com/atopos31/llmio/service`