### PR TITLE
feat: 新增模型关联 ExtraBody 额外请求体参数

### DIFF
--- a/handler/api.go
+++ b/handler/api.go
@@ -52,6 +52,7 @@ type ModelWithProviderRequest struct {
 	Image            bool              `json:"image"`
 	WithHeader       bool              `json:"with_header"`
 	CustomerHeaders  map[string]string `json:"customer_headers"`
+	ExtraBody        map[string]any    `json:"extra_body"`
 	Weight           int               `json:"weight"`
 }
 
@@ -603,6 +604,11 @@ func CreateModelProvider(c *gin.Context) {
 		customerHeaders = map[string]string{}
 	}
 
+	extraBody := req.ExtraBody
+	if extraBody == nil {
+		extraBody = map[string]any{}
+	}
+
 	modelProvider := models.ModelWithProvider{
 		ModelID:          req.ModelID,
 		ProviderModel:    req.ProviderModel,
@@ -612,6 +618,7 @@ func CreateModelProvider(c *gin.Context) {
 		Image:            &req.Image,
 		WithHeader:       &req.WithHeader,
 		CustomerHeaders:  customerHeaders,
+		ExtraBody:        extraBody,
 		Weight:           req.Weight,
 	}
 
@@ -648,6 +655,11 @@ func UpdateModelProvider(c *gin.Context) {
 		customerHeaders = map[string]string{}
 	}
 
+	extraBody := req.ExtraBody
+	if extraBody == nil {
+		extraBody = map[string]any{}
+	}
+
 	// Check if model-provider association exists
 	_, err = gorm.G[models.ModelWithProvider](models.DB).Where("id = ?", id).First(c.Request.Context())
 	if err != nil {
@@ -669,6 +681,7 @@ func UpdateModelProvider(c *gin.Context) {
 		Image:            &req.Image,
 		WithHeader:       &req.WithHeader,
 		CustomerHeaders:  customerHeaders,
+		ExtraBody:        extraBody,
 		Weight:           req.Weight,
 	}
 

--- a/models/model.go
+++ b/models/model.go
@@ -47,6 +47,7 @@ type ModelWithProvider struct {
 	WithHeader       *bool             // 是否透传header
 	Status           *bool             // 是否启用
 	CustomerHeaders  map[string]string `gorm:"serializer:json"` // 自定义headers
+	ExtraBody        map[string]any    `gorm:"serializer:json"` // 额外请求体参数
 	Weight           int
 }
 

--- a/service/chat.go
+++ b/service/chat.go
@@ -17,6 +17,7 @@ import (
 	"github.com/atopos31/llmio/pkg/token"
 	"github.com/atopos31/llmio/providers"
 	"github.com/samber/lo"
+	"github.com/tidwall/sjson"
 	"gorm.io/gorm"
 )
 
@@ -112,7 +113,18 @@ func BalanceChat(ctx context.Context, start time.Time, style string, before Befo
 			withHeader := lo.FromPtrOr(modelWithProvider.WithHeader, false)
 			headers := BuildHeaders(reqMeta.Header, withHeader, modelWithProvider.CustomerHeaders, before.Stream)
 
-			req, err := chatModel.BuildReq(ctx, headers, modelWithProvider.ProviderModel, before.raw)
+			// 注入 ExtraBody 参数到请求体
+			rawBody := before.raw
+			if len(modelWithProvider.ExtraBody) > 0 {
+				for key, value := range modelWithProvider.ExtraBody {
+					rawBody, err = sjson.SetBytes(rawBody, key, value)
+					if err != nil {
+						slog.Warn("failed to set extra body key", "key", key, "error", err)
+					}
+				}
+			}
+
+			req, err := chatModel.BuildReq(ctx, headers, modelWithProvider.ProviderModel, rawBody)
 			if err != nil {
 				retryLog <- log.WithError(err)
 				// 构建请求失败 移除待选

--- a/webui/src/i18n/locales/en/models.json
+++ b/webui/src/i18n/locales/en/models.json
@@ -125,7 +125,10 @@
     "weight": "Weight (must be greater than 0)",
     "header_key_placeholder": "Header Key",
     "header_value_placeholder": "Header Value",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "extra_body": "Extra Request Body",
+    "extra_body_placeholder": "{\"chat_template_kwargs\": {\"enable_thinking\": false}}",
+    "extra_body_hint": "Injects key-value pairs from this JSON into the request body sent to the provider, overriding any matching user-supplied parameters"
   },
   "test_dialog": {
     "title": "Model Test",

--- a/webui/src/i18n/locales/zh-CN/models.json
+++ b/webui/src/i18n/locales/zh-CN/models.json
@@ -125,7 +125,10 @@
     "weight": "权重 (必须大于0)",
     "header_key_placeholder": "Header Key",
     "header_value_placeholder": "Header Value",
-    "cancel": "取消"
+    "cancel": "取消",
+    "extra_body": "额外请求体参数",
+    "extra_body_placeholder": "{\"chat_template_kwargs\": {\"enable_thinking\": false}}",
+    "extra_body_hint": "将 JSON 中的键值对注入到发往 provider 的请求体中，覆盖用户请求中的同名参数"
   },
   "test_dialog": {
     "title": "模型测试",

--- a/webui/src/i18n/locales/zh-TW/models.json
+++ b/webui/src/i18n/locales/zh-TW/models.json
@@ -125,7 +125,10 @@
     "weight": "權重 (必須大於0)",
     "header_key_placeholder": "Header Key",
     "header_value_placeholder": "Header Value",
-    "cancel": "取消"
+    "cancel": "取消",
+    "extra_body": "額外請求體參數",
+    "extra_body_placeholder": "{\"chat_template_kwargs\": {\"enable_thinking\": false}}",
+    "extra_body_hint": "將 JSON 中的鍵值對注入到發往 provider 的請求體中，覆蓋用戶請求中的同名參數"
   },
   "test_dialog": {
     "title": "模型測試",

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -34,6 +34,7 @@ export interface ModelWithProvider {
   Image: boolean;
   WithHeader: boolean;
   CustomerHeaders: Record<string, string> | null;
+  ExtraBody: Record<string, unknown> | null;
   Status: boolean | null;
   Weight: number;
 }
@@ -329,6 +330,7 @@ export async function createModelProvider(association: {
   image: boolean;
   with_header: boolean;
   customer_headers: Record<string, string>;
+  extra_body: Record<string, unknown>;
   weight: number;
 }): Promise<ModelWithProvider> {
   return apiRequest<ModelWithProvider>('/model-providers', {
@@ -346,6 +348,7 @@ export async function updateModelProvider(id: number, association: {
   image?: boolean;
   with_header?: boolean;
   customer_headers?: Record<string, string>;
+  extra_body?: Record<string, unknown>;
   weight?: number;
 }): Promise<ModelWithProvider> {
   return apiRequest<ModelWithProvider>(`/model-providers/${id}`, {

--- a/webui/src/routes/model-providers/model-provider-form-dialog.tsx
+++ b/webui/src/routes/model-providers/model-provider-form-dialog.tsx
@@ -340,6 +340,28 @@ export function ModelProviderFormDialog({
 
               <FormField
                 control={form.control}
+                name="extra_body"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('association_form.extra_body')}</FormLabel>
+                    <FormControl>
+                      <textarea
+                        {...field}
+                        className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                        placeholder={t('association_form.extra_body_placeholder')}
+                        rows={3}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      {t('association_form.extra_body_hint')}
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
                 name="weight"
                 render={({ field }) => (
                   <FormItem>

--- a/webui/src/routes/model-providers/use-model-provider-form.ts
+++ b/webui/src/routes/model-providers/use-model-provider-form.ts
@@ -21,6 +21,7 @@ export const modelProviderFormSchema = z.object({
   with_header: z.boolean(),
   weight: z.number().positive({ message: "权重必须大于0" }),
   customer_headers: z.array(headerPairSchema).default([]),
+  extra_body: z.string().default(""),
 });
 
 export type ModelProviderFormValues = z.input<typeof modelProviderFormSchema>;
@@ -56,6 +57,7 @@ export const useModelProviderForm = ({
       with_header: false,
       weight: 1,
       customer_headers: [],
+      extra_body: "",
     };
   };
 
@@ -87,6 +89,15 @@ export const useModelProviderForm = ({
       }
     });
 
+    let extraBody: Record<string, unknown> = {};
+    if (values.extra_body && values.extra_body.trim()) {
+      try {
+        extraBody = JSON.parse(values.extra_body);
+      } catch {
+        // ignore parse errors, send empty object
+      }
+    }
+
     return {
       model_id: values.model_id,
       provider_name: values.provider_name,
@@ -96,6 +107,7 @@ export const useModelProviderForm = ({
       image: values.image,
       with_header: values.with_header,
       customer_headers: headers,
+      extra_body: extraBody,
       weight: values.weight,
     };
   };
@@ -106,6 +118,10 @@ export const useModelProviderForm = ({
       key,
       value,
     }));
+    let extraBodyStr = "";
+    if (association.ExtraBody && Object.keys(association.ExtraBody).length > 0) {
+      extraBodyStr = JSON.stringify(association.ExtraBody, null, 2);
+    }
     form.reset({
       model_id: association.ModelID,
       provider_name: association.ProviderModel,
@@ -116,6 +132,7 @@ export const useModelProviderForm = ({
       with_header: association.WithHeader,
       weight: association.Weight,
       customer_headers: headerPairs.length ? headerPairs : [],
+      extra_body: extraBodyStr,
     });
     setOpen(true);
   };


### PR DESCRIPTION
支持在模型关联配置中注入额外的请求体参数（如关闭思考模式的 chat_template_kwargs）， 自动合并到发往 provider 的请求体中
以本地部署的 Qwen3 为例，未添加时，直接请求默认思考
<img width="1585" height="1090" alt="iShot_2026-04-02_19 05 26" src="https://github.com/user-attachments/assets/ad194845-0cb9-4cea-a8a8-a1436f96975f" />
添加参数后，以相同请求访问，请求体生效，没有思考
<img width="1558" height="940" alt="iShot_2026-04-02_19 07 36" src="https://github.com/user-attachments/assets/6fc4c56d-2ab5-4507-9ce2-def8cf5c176e" />

